### PR TITLE
Add SignInService for decoupling from SignInManager

### DIFF
--- a/API.Application/API.Application.csproj
+++ b/API.Application/API.Application.csproj
@@ -15,10 +15,4 @@
     <ItemGroup>
         <ProjectReference Include="..\API.Domain\API.Domain.csproj" />
     </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Microsoft.AspNetCore.Identity">
-        <HintPath>..\..\..\..\..\.dotnet\shared\Microsoft.AspNetCore.App\8.0.0\Microsoft.AspNetCore.Identity.dll</HintPath>
-      </Reference>
-    </ItemGroup>
 </Project>

--- a/API.Application/Contracts/ISignInService.cs
+++ b/API.Application/Contracts/ISignInService.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace API.Application.Contracts;
+
+public interface ISignInService
+{
+    public Task<SignInResult> PasswordSignInAsync(
+        string userName,
+        string password,
+        bool isPersistent,
+        bool lockoutOnFailure);
+
+    public Task<SignInResult> TwoFactorAuthenticatorSignInAsync(
+        string code,
+        bool isPersistent,
+        bool rememberClient);
+
+    public Task<SignInResult> TwoFactorRecoveryCodeSignInAsync(
+        string recoveryCode);
+
+    public Task SignOutAsync();
+}

--- a/API.Application/Services/AuthSessionService.cs
+++ b/API.Application/Services/AuthSessionService.cs
@@ -1,18 +1,16 @@
+using API.Application.Contracts;
 using API.Domain.Contracts.Services;
 using API.Domain.Dto;
-using API.Domain.Entities;
-using Microsoft.AspNetCore.Identity;
 
 namespace API.Application.Services;
 
-public class AuthSessionService(SignInManager<ApplicationUser> signInManager) : IAuthSessionService
+public class AuthSessionService(ISignInService signInService) : IAuthSessionService
 {
     public async Task Create(AuthSessionCreationDataDto data)
     {
         const bool isPersistent = true;
-        signInManager.AuthenticationScheme = IdentityConstants.ApplicationScheme;
         
-        var result = await signInManager.PasswordSignInAsync(
+        var result = await signInService.PasswordSignInAsync(
             data.Email,
             data.Password,
             isPersistent,
@@ -23,7 +21,7 @@ public class AuthSessionService(SignInManager<ApplicationUser> signInManager) : 
         {
             if (!string.IsNullOrEmpty(data.TwoFactorCode))
             {
-                result = await signInManager.TwoFactorAuthenticatorSignInAsync(
+                result = await signInService.TwoFactorAuthenticatorSignInAsync(
                     data.TwoFactorCode,
                     isPersistent,
                     rememberClient: isPersistent
@@ -31,7 +29,7 @@ public class AuthSessionService(SignInManager<ApplicationUser> signInManager) : 
             }
             else if (!string.IsNullOrEmpty(data.TwoFactorRecoveryCode))
             {
-                result = await signInManager.TwoFactorRecoveryCodeSignInAsync(
+                result = await signInService.TwoFactorRecoveryCodeSignInAsync(
                     data.TwoFactorRecoveryCode
                 );
             }
@@ -48,6 +46,6 @@ public class AuthSessionService(SignInManager<ApplicationUser> signInManager) : 
 
     public async Task InvalidateCurrentSession()
     {
-        await signInManager.SignOutAsync();
+        await signInService.SignOutAsync();
     }
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,9 +1,11 @@
+using API.Application.Contracts;
 using API.Infrastructure;
 using API.Domain.Entities;
 using API.Domain.Contracts.Configuration;
 using API.Domain.Contracts.Services;
 using API.Application.Services;
 using API.Infrastructure.Database;
+using API.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -46,6 +48,7 @@ builder.Services.AddScoped<ICurrentWeatherApiService, CurrentWeatherApiService>(
 
 builder.Services.AddScoped<IIdentityService, IdentityService>();
 builder.Services.AddScoped<IAuthSessionService, AuthSessionService>();
+builder.Services.AddScoped<ISignInService, SignInService>();
 
 var app = builder.Build();
 

--- a/API/Services/SignInService.cs
+++ b/API/Services/SignInService.cs
@@ -1,0 +1,21 @@
+using API.Application.Contracts;
+using API.Domain.Entities;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace API.Services;
+
+public class SignInService : SignInManager<ApplicationUser>, ISignInService
+{
+    public SignInService(
+        UserManager<ApplicationUser> userManager,
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<ApplicationUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<ApplicationUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<ApplicationUser> confirmation) : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
+    {
+    }
+}


### PR DESCRIPTION
Created a SignInService class as an adapter over the SignInManager/ApplicationUser class from the ASP.NET Identity library and updated all usages, decoupling application code from directly depending on the library.

Reason for change is to make the application code more robust and easy to test by depending on abstractions (ISignInService) and not concrete implementations from third-party library, which might change in future versions. Also, it's a part of an ongoing effort to keep the domain model clean, and keeping all Identity related code isolated in the services layer.